### PR TITLE
feat: convert to remote HTTP MCP server for Render deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,18 @@
 # Frontapp API credentials
-FRONTAPP_API_KEY=your_frontapp_api_key_here
+FRONTAPP_API_TOKEN=your_frontapp_api_token_here
 
 # Webhook configuration
 WEBHOOK_SECRET=your_webhook_secret_here
 WEBHOOK_BASE_URL=https://your-webhook-url.com
 
-# Server configuration
+# Transport mode: "http" (default, for remote hosting) or "stdio" (for local Claude Code)
+TRANSPORT_MODE=http
+
+# Auth token to protect the /mcp endpoint — clients must send: Authorization: Bearer <token>
+# Generate one with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+MCP_AUTH_TOKEN=your_secret_token_here
+
+# Server configuration (Render sets PORT automatically; override only for local dev)
 PORT=3000
 
 # Logging and Monitoring

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,12 +41,15 @@ RUN addgroup -g 1001 -S mcp && \
 # Switch to non-root user
 USER mcp
 
-# Health check
-HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD node -e "process.exit(0)" || exit 1
+# Expose HTTP port
+EXPOSE 3000
+
+# HTTP health check against the /health endpoint
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD wget -qO- http://localhost:3000/health || exit 1
 
 # Set environment variables
 ENV NODE_ENV=production
 
-# Run the MCP server
+# Run the MCP server in HTTP mode (default)
 CMD ["node", "dist/index.js"]

--- a/package.json
+++ b/package.json
@@ -23,10 +23,12 @@
   "author": "Your Name",
   "license": "MIT",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.4",
-    "axios": "^1.7.9"
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "axios": "^1.7.9",
+    "express": "^4.21.0"
   },
   "devDependencies": {
+    "@types/express": "^4.17.21",
     "@types/node": "^22.10.2",
     "typescript": "^5.7.2"
   }

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,17 @@
+services:
+  - type: web
+    name: frontapp-mcp-server
+    env: node
+    plan: free
+    region: oregon
+    buildCommand: npm ci && npm run build
+    startCommand: node dist/index.js
+    healthCheckPath: /health
+    envVars:
+      - key: NODE_ENV
+        value: production
+      # Render automatically sets PORT — do not override it here
+      - key: FRONTAPP_API_TOKEN
+        sync: false   # Set this manually in Render dashboard
+      - key: MCP_AUTH_TOKEN
+        sync: false   # Set this manually — used to protect your /mcp endpoint

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
@@ -21,6 +22,7 @@ import {
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import axios, { AxiosInstance } from 'axios';
+import express from 'express';
 
 const API_BASE_URL = 'https://api2.frontapp.com';
 
@@ -53,6 +55,10 @@ class FrontappMCPServer {
 
     this.setupHandlers();
     this.setupErrorHandling();
+  }
+
+  async connectTo(transport: any): Promise<void> {
+    await this.server.connect(transport);
   }
 
   private setupErrorHandling(): void {
@@ -3307,5 +3313,73 @@ if (!apiToken) {
   process.exit(1);
 }
 
-const server = new FrontappMCPServer(apiToken);
-server.run().catch(console.error);
+if (process.env.TRANSPORT_MODE === 'stdio') {
+  // Legacy local stdio mode (for Claude Code desktop / Docker wrapper)
+  const server = new FrontappMCPServer(apiToken);
+  server.run().catch(console.error);
+} else {
+  // HTTP server mode — default for remote hosting (Render, Railway, Fly.io, etc.)
+  const port = parseInt(process.env.PORT || '3000', 10);
+  const authToken = process.env.MCP_AUTH_TOKEN;
+
+  const app = express();
+  app.use(express.json());
+
+  // CORS headers required by Claude.ai and other remote MCP clients
+  app.use((_req, res, next) => {
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, mcp-session-id');
+    res.setHeader('Access-Control-Expose-Headers', 'mcp-session-id');
+    if (_req.method === 'OPTIONS') {
+      res.sendStatus(204);
+      return;
+    }
+    next();
+  });
+
+  // Health check — used by Render to verify the service is up
+  app.get('/health', (_req, res) => {
+    res.json({ status: 'ok', service: 'frontapp-mcp-server', version: '1.0.0' });
+  });
+
+  app.get('/', (_req, res) => {
+    res.json({
+      service: 'Frontapp MCP Server',
+      mcp_endpoint: '/mcp',
+      auth_required: authToken ? true : false,
+    });
+  });
+
+  // Optional Bearer token auth — set MCP_AUTH_TOKEN env var to enable
+  const checkAuth = (req: any, res: any, next: any) => {
+    if (!authToken) return next();
+    const auth = req.headers.authorization;
+    if (!auth || auth !== `Bearer ${authToken}`) {
+      res.status(401).json({ error: 'Unauthorized — provide Bearer token in Authorization header' });
+      return;
+    }
+    next();
+  };
+
+  // MCP Streamable HTTP endpoint — handles POST (requests) and GET (SSE stream)
+  app.all('/mcp', checkAuth, async (req: any, res: any) => {
+    try {
+      const mcpInstance = new FrontappMCPServer(apiToken);
+      const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+      await mcpInstance.connectTo(transport);
+      await transport.handleRequest(req, res, req.body);
+    } catch (err: any) {
+      console.error('MCP request error:', err.message);
+      if (!res.headersSent) {
+        res.status(500).json({ error: 'Internal server error' });
+      }
+    }
+  });
+
+  app.listen(port, '0.0.0.0', () => {
+    console.error(`Frontapp MCP server running on port ${port}`);
+    console.error(`MCP endpoint: POST http://0.0.0.0:${port}/mcp`);
+    console.error(`Auth: ${authToken ? 'Bearer token required (MCP_AUTH_TOKEN set)' : 'open — set MCP_AUTH_TOKEN to protect'}`);
+  });
+}


### PR DESCRIPTION
Replace StdioServerTransport with StreamableHTTPServerTransport so the server can run as a remote MCP endpoint accessible from Claude.ai and any team member. Defaults to HTTP mode; set TRANSPORT_MODE=stdio to keep the original local Docker behavior.

Changes:
- Upgrade @modelcontextprotocol/sdk to 1.29.0 (StreamableHTTP support)
- Add express for HTTP server; CORS headers for Claude.ai compatibility
- POST /mcp handles MCP requests (stateless, one FrontappMCPServer per req)
- GET /health for Render health checks
- Optional Bearer token auth via MCP_AUTH_TOKEN env var
- render.yaml for one-click Render web service deployment
- Dockerfile: EXPOSE 3000 + HTTP health check

https://claude.ai/code/session_01V4zTz1CEBNbcq8MopqtqmW