### PR TITLE
Add pagination support to search_conversations

### DIFF
--- a/frontapp_mcp.ts
+++ b/frontapp_mcp.ts
@@ -102,6 +102,7 @@ class FrontappMCPServer {
             properties: {
               query: { type: 'string', description: 'Search query (e.g., "tag:urgent status:open")' },
               limit: { type: 'number', description: 'Number of results (max 100, default 50)' },
+              page_token: { type: 'string', description: 'Pagination token from previous response for fetching next page of results' },
             },
             required: ['query'],
           },
@@ -1935,7 +1936,7 @@ class FrontappMCPServer {
             result = await this.getConversation(args.conversation_id);
             break;
           case 'search_conversations':
-            result = await this.searchConversations(args.query, args.limit);
+            result = await this.searchConversations(args.query, args.limit, args.page_token);
             break;
           case 'update_conversation':
             result = await this.updateConversation(args);
@@ -2429,10 +2430,10 @@ class FrontappMCPServer {
     return response.data;
   }
 
-  private async searchConversations(query: string, limit?: number) {
+  private async searchConversations(query: string, limit?: number, pageToken?: string) {
     const encodedQuery = encodeURIComponent(query);
     const response = await this.axiosInstance.get(`/conversations/search/${encodedQuery}`, {
-      params: { limit },
+      params: { limit, page_token: pageToken },
     });
     return response.data;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,6 +102,7 @@ class FrontappMCPServer {
             properties: {
               query: { type: 'string', description: 'Search query (e.g., "tag:urgent status:open")' },
               limit: { type: 'number', description: 'Number of results (max 100, default 50)' },
+              page_token: { type: 'string', description: 'Pagination token from previous response for fetching next page of results' },
             },
             required: ['query'],
           },
@@ -1936,7 +1937,7 @@ class FrontappMCPServer {
             result = await this.getConversation(typedArgs.conversation_id);
             break;
           case 'search_conversations':
-            result = await this.searchConversations(typedArgs.query, typedArgs.limit);
+            result = await this.searchConversations(typedArgs.query, typedArgs.limit, typedArgs.page_token);
             break;
           case 'update_conversation':
             result = await this.updateConversation(typedArgs);
@@ -2430,10 +2431,10 @@ class FrontappMCPServer {
     return response.data;
   }
 
-  private async searchConversations(query: string, limit?: number) {
+  private async searchConversations(query: string, limit?: number, pageToken?: string) {
     const encodedQuery = encodeURIComponent(query);
     const response = await this.axiosInstance.get(`/conversations/search/${encodedQuery}`, {
-      params: { limit },
+      params: { limit, page_token: pageToken },
     });
     return response.data;
   }


### PR DESCRIPTION
> **Please note:** Claude made and verified these changes.

## Summary

- Adds `page_token` parameter to the `search_conversations` tool, enabling cursor-based pagination through search results
- Without this, only the first page (max 100) of search results is accessible — for queries matching hundreds of conversations, the rest are unreachable
- Updates both `src/index.ts` and `frontapp_mcp.ts` to stay in sync

## Details

The Front API returns a `_pagination.next` URL in search responses when more results are available. This URL contains a `page_token` query parameter. By passing that token back in a subsequent `search_conversations` call, the next page of results is returned.

Other list tools in this server (e.g., `list_conversations`, `list_conversation_messages`) already support `page_token` — this brings `search_conversations` in line with them.

## Test plan

- [ ] Search with `limit: 2` and verify `_pagination.next` is present in the response
- [ ] Extract `page_token` from the pagination URL and pass it in a follow-up search call
- [ ] Verify the second call returns different results and a new `_pagination.next` token
- [ ] Verify omitting `page_token` still works as before (returns first page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)